### PR TITLE
Closes #23 Progress logging

### DIFF
--- a/src/FjordSim.jl
+++ b/src/FjordSim.jl
@@ -12,6 +12,7 @@ export
     # utils
     recursive_merge,
     progress,
+    progress_callback,
     cell_advection_timescale_coupled_model,
     # atmosphere
     NORA3PrescribedAtmosphere,

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -2,6 +2,7 @@ module Utils
 
 export compute_faces,
     progress,
+    progress_callback,
     safe_execute,
     extract_z_faces,
     netcdf_to_jld2,
@@ -27,30 +28,55 @@ end
 
 wall_time = Ref(time_ns())
 
-function progress(sim)
+_progress_tracers(tracers::Symbol) = (tracers,)
+
+function _progress_tracers(tracers)
+    tracer_names = Tuple(tracers)
+    all(tracer -> tracer isa Symbol, tracer_names) ||
+        throw(ArgumentError("progress tracers must be Symbols."))
+    return tracer_names
+end
+
+function _tracer_extrema_message(model_tracers, tracer_name)
+    if !hasproperty(model_tracers, tracer_name)
+        available_tracers = join([":" * String(name) for name in propertynames(model_tracers)], ", ")
+        throw(ArgumentError("Tracer :$tracer_name is not defined. Available tracers: $available_tracers."))
+    end
+
+    tracer = getproperty(model_tracers, tracer_name)
+    tracer_max = maximum(interior(tracer))
+    tracer_min = minimum(interior(tracer))
+    units = tracer_name === :T ? " ᵒC" : ""
+
+    return @sprintf("extrema(%s): (%.2f, %.2f)%s", String(tracer_name), tracer_max, tracer_min, units)
+end
+
+function progress(sim; tracers = (:T,), wall_time_reference = wall_time)
     ocean = sim.model.ocean
     u, v, w = ocean.model.velocities
-    T = ocean.model.tracers.T
-
-    Tmax = maximum(interior(T))
-    Tmin = minimum(interior(T))
 
     umax = (maximum(abs, interior(u)), maximum(abs, interior(v)), maximum(abs, interior(w)))
 
-    step_time = 1e-9 * (time_ns() - wall_time[])
+    step_time = 1e-9 * (time_ns() - wall_time_reference[])
 
     msg = @sprintf("Iter: %d, time: %s, Δt: %s", iteration(sim), prettytime(sim), prettytime(sim.Δt))
-    msg *= @sprintf(
-        ", max|u|: (%.2e, %.2e, %.2e) m s⁻¹, extrema(T): (%.2f, %.2f) ᵒC, wall time: %s",
-        umax...,
-        Tmax,
-        Tmin,
-        prettytime(step_time)
-    )
+    msg *= @sprintf(", max|u|: (%.2e, %.2e, %.2e) m s⁻¹", umax...)
+
+    tracer_names = _progress_tracers(tracers)
+    for tracer_name in tracer_names
+        msg *= ", " * _tracer_extrema_message(ocean.model.tracers, tracer_name)
+    end
+
+    msg *= @sprintf(", wall time: %s", prettytime(step_time))
 
     @info msg
 
-    wall_time[] = time_ns()
+    wall_time_reference[] = time_ns()
+end
+
+function progress_callback(; tracers = (:T,))
+    wall_time_reference = Ref(time_ns())
+    return sim -> progress(sim; tracers, wall_time_reference)
 end
 
 function safe_execute(callable)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,39 @@ using Test
 using NCDatasets
 using Oceananigans
 using Oceananigans.BoundaryConditions: FluxBoundaryCondition
+import Oceananigans: iteration
+import Oceananigans.Fields: interior
+import Oceananigans.Utils: prettytime
+
+struct MockProgressField
+    values
+end
+
+interior(field::MockProgressField) = field.values
+
+struct MockProgressSimulation
+    model
+    Δt
+end
+
+iteration(::MockProgressSimulation) = 7
+prettytime(::MockProgressSimulation) = "12 hours"
+
+function mock_progress_simulation()
+    u = MockProgressField([1.0, -2.0])
+    v = MockProgressField([0.5, -0.25])
+    w = MockProgressField([0.01, -0.02])
+    T = MockProgressField([3.0, 5.0])
+    NUT = MockProgressField([1.0, 2.5])
+    HET = MockProgressField([0.1, 0.4])
+
+    ocean_model = (
+        velocities = (u, v, w),
+        tracers = (T = T, NUT = NUT, HET = HET),
+    )
+
+    return MockProgressSimulation((ocean = (model = ocean_model,),), 1.0)
+end
 
 @testset "Backward Compatibility — API Exports" begin
     # Verify all exported symbols are present in the public interface
@@ -13,6 +46,7 @@ using Oceananigans.BoundaryConditions: FluxBoundaryCondition
         :coupled_hydrostatic_simulation,
         :recursive_merge,
         :progress,
+        :progress_callback,
         :cell_advection_timescale_coupled_model,
         :NORA3PrescribedAtmosphere,
         :NORA3PrescribedRadiation,
@@ -30,6 +64,7 @@ using Oceananigans.BoundaryConditions: FluxBoundaryCondition
         (:Utils, :extract_z_faces),
         (:Utils, :netcdf_to_jld2),
         (:Utils, :save_fts),
+        (:Utils, :progress_callback),
         (:FDatasets, :DSForcing),
         (:FDatasets, :DSResults),
         (:FDatasets, :last_date),
@@ -39,6 +74,22 @@ using Oceananigans.BoundaryConditions: FluxBoundaryCondition
         mod = getfield(FjordSim, module_name)
         @test isdefined(mod, sym)  # All submodule exports must be defined
     end
+end
+
+@testset "Configurable progress logging" begin
+    sim = mock_progress_simulation()
+
+    @test_logs (:info, r"max\|u\|: .*extrema\(T\): \(5\.00, 3\.00\) ᵒC, extrema\(NUT\): \(2\.50, 1\.00\), wall time:") progress(
+        sim;
+        tracers = (:T, :NUT),
+        wall_time_reference = Ref(time_ns()),
+    )
+
+    callback = progress_callback(; tracers = (:HET,))
+    @test callback isa Function
+    @test_logs (:info, r"extrema\(HET\): \(0\.40, 0\.10\), wall time:") callback(sim)
+
+    @test_throws ArgumentError progress(sim; tracers = (:POM,), wall_time_reference = Ref(time_ns()))
 end
 
 @testset "Backward Compatibility — Function Signatures" begin


### PR DESCRIPTION
Requested by @e-yakushev. 
This is my first attempt at a contribution to this project, so please let me know if I have misunderstood anything!

## Summary

Adds configurable tracer diagnostics to `FjordSim.Utils.progress`.

Previously, `progress(sim)` always logged extrema for `T`. This change keeps that
default behavior, but adds a `tracers` keyword so users can choose which tracer
extrema appear in the progress message:

```julia
simulation.callbacks[:progress] = Callback(
    progress_callback(; tracers = (:T, :NUT, :HET, :POM)),
    TimeInterval(24hours),
)
```
It also adds `progress_callback(; tracers = (:T,))`, which returns a callback function with its own wall-time reference.

## Changes

- Add `progress(sim; tracers = (:T,))`
- Add and export `progress_callback(; tracers = (:T,))`
- Preserve existing `progress(sim)` behavior by default
- Report a clear `ArgumentError` if a requested tracer is not present
- Add tests for configurable tracer logging and callback construction